### PR TITLE
narrowTypeByProperty improvement

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,13 +6,13 @@
   "packages": {
     "": {
       "name": "vuepal",
-      "version": "3.0.0-alpha.4",
+      "version": "3.0.2",
       "license": "MIT",
       "dependencies": {
         "change-case": "^5.4.4",
         "fzf": "^0.5.2",
         "nuxt-graphql-middleware": "^5.1.0",
-        "nuxt-language-negotiation": "^2.0.0-alpha.2",
+        "nuxt-language-negotiation": "^2.0.0",
         "yaml": "^2.4.1"
       },
       "devDependencies": {
@@ -14320,9 +14320,9 @@
       }
     },
     "node_modules/nuxt-language-negotiation": {
-      "version": "2.0.0-alpha.2",
-      "resolved": "https://registry.npmjs.org/nuxt-language-negotiation/-/nuxt-language-negotiation-2.0.0-alpha.2.tgz",
-      "integrity": "sha512-yf4H8DYS3smJr6pgWyQ1r26REpPVWqK3xcLESmcfmdsn8zLeErtszmkLfnglHJR5Gpx8bzziYAf77zZvjjSj5A==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/nuxt-language-negotiation/-/nuxt-language-negotiation-2.0.0.tgz",
+      "integrity": "sha512-doTgfuLSbiTPfVEpCFiIuHda3IRaHu20Ssr4aZMVtgsOl97q7ncMAbQRLEvJEdGKZRtcyvPYAuVuozVom7W8Ug==",
       "dependencies": {
         "intl-parse-accept-language": "^1.0.0",
         "iso-639-1": "^3.1.5"

--- a/playground/app/app.vue
+++ b/playground/app/app.vue
@@ -16,10 +16,32 @@
 <script setup lang="ts">
 import { VuepalLocalTasks, VuepalAdminToolbar } from '#components'
 import { useTrustedOrigin } from '#imports'
+import { narrowTypeByProperty } from '#vuepal/helpers/graphql'
 
 const originErrorMessage = useTrustedOrigin({
   redirect: true,
 })
+
+// small section which ensures narrowTypeByProperty works
+const a = { a: 5, aa: 7 }
+const b = { b: 6, bb: 4 }
+const c = Math.random() < 0.5 ? a : b
+const d = narrowTypeByProperty(c, 'a')
+
+d?.a
+d?.aa
+// @ts-expect-error
+d?.b
+// @ts-expect-error
+d?.bb
+
+const e: { a?: number, e: number } = { e: 4 }
+const f = Math.random() < 0.5 ? a : e
+const g = narrowTypeByProperty(f, 'a')
+
+g?.a
+// @ts-expect-error
+g?.e
 </script>
 
 <style lang="css">

--- a/src/runtime/composables/useDrupalRouteQuery/index.ts
+++ b/src/runtime/composables/useDrupalRouteQuery/index.ts
@@ -56,6 +56,7 @@ export async function useDrupalRouteQuery<
   if (
     data.value &&
     'route' in data.value &&
+    data.value.route &&
     !['EntityCanonicalUrl', 'DefaultEntityUrl'].includes(
       data.value.route?.__typename,
     )

--- a/src/runtime/helpers/graphql.ts
+++ b/src/runtime/helpers/graphql.ts
@@ -87,6 +87,13 @@ export function removeTypename<T extends { __typename?: string }>(
   return clone
 }
 
+type KeysOfUnion<T> = T extends T ? keyof T : never
+type HasKey<T, K extends PropertyKey> = T extends object
+  ? K extends keyof T
+    ? T
+    : never
+  : never
+
 /**
  * Narrow a GraphQL type by property.
  *
@@ -95,12 +102,12 @@ export function removeTypename<T extends { __typename?: string }>(
  *
  * The returned type is narrowed using the given property.
  */
-export function narrowTypeByProperty<T extends object, K extends keyof T>(
-  obj: T | object | null | undefined,
-  propName: K,
-): T | undefined {
+export function narrowTypeByProperty<
+  T extends object,
+  K extends KeysOfUnion<T>,
+>(obj: T | object | null | undefined, propName: K): HasKey<T, K> | undefined {
   if (obj && propName in obj) {
-    return obj as T
+    return obj as HasKey<T, K>
   }
   return undefined
 }


### PR DESCRIPTION
narrowTypeByProperty now also work with Unions where one type does not have the property.
Previously it only work on types where all had the property at least as an optional one.