### PR TITLE
remove wrong function overload

### DIFF
--- a/src/runtime/composables/useDrupalRoute/index.ts
+++ b/src/runtime/composables/useDrupalRoute/index.ts
@@ -46,24 +46,6 @@ type UseDrupalRouteQueryInput =
   | undefined
   | null
 
-// Overload signature to make the return type nullable when setting noError to
-// true, because it allows the composable to return if no route entity is
-// available.
-export function useDrupalRoute<T extends object = object>(
-  queryInput: UseDrupalRouteQueryInput,
-  options: { noError: true },
-  providedRoute?: RouteLocationNormalizedLoaded,
-): Promise<UseDrupalRoute<T | undefined>>
-
-// Overload signature to make the return type non nullable without options or
-// when the option noError is false, because the code ensures that the return
-// type is always going to be the passed in generic type.
-export function useDrupalRoute<T extends object = object>(
-  queryInput: UseDrupalRouteQueryInput,
-  options?: { noError?: false } | null,
-  providedRoute?: RouteLocationNormalizedLoaded,
-): Promise<UseDrupalRoute<T>>
-
 /**
  * Composable that handles the Drupal routing for 404, redirects, metatags and
  * entities.


### PR DESCRIPTION
In the case of a redirect it is still possible that the entity is undefined. I am not sure if adding a throw there makes sense.